### PR TITLE
Fix when response isn't gzipped

### DIFF
--- a/tespeed.py
+++ b/tespeed.py
@@ -412,7 +412,11 @@ class TeSpeed:
     # Decompress gzipped response
         data = StringIO(response.read())
         gzipper = gzip.GzipFile(fileobj=data)
-        return gzipper.read()
+        try:
+            return gzipper.read()
+        except IOError as e:
+            # Response isn't gzipped, therefore return the data.
+            return data.getvalue()
 
 
     def FindBestServer(self):


### PR DESCRIPTION
This fix solves the problem when the response xml from SpeedTest isn't gzipped.
